### PR TITLE
Fix images rendered in for loops

### DIFF
--- a/aeroolib/plugins/opendocument.py
+++ b/aeroolib/plugins/opendocument.py
@@ -682,7 +682,12 @@ class Template(MarkupTemplate):
         xpath_expr = "//draw:frame[starts-with(@draw:name, 'image:')]"
         for draw in tree.xpath(xpath_expr, namespaces=self.namespaces):
             d_name = draw.attrib[draw_name][6:].strip()
-            draw.attrib[draw_name] = "Aeroo picture "
+
+            # Libreoffice will automatically allocate a name to the image frame
+            # If we let something in the name attribute, only the first 2
+            # frames will be rendered.
+            del draw.attrib[draw_name]
+
             attr_expr = "__aeroo_make_href(%s)" % d_name
             image_node = EtreeElement(draw_image,
                                       attrib={py_attrs: attr_expr},


### PR DESCRIPTION
When rendering more than 2 images in a report, only the 2 first would appear.
This is because Libreoffice does not let 2 images have the same name.
Before this fix, the first image was generated with name='Aeroo Image '
and the second with name='Image2'. Any other image was not rendered.

If we let the attribute empty, Libreoffice generates a name automatically for
each image which solves the problem.